### PR TITLE
Support Firefox Flatpak for Linux profile directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,7 @@ The dotbot-firefox plugin is aware of the following default directories:
 *   ``~/Library/Application Support/Firefox/Profiles`` (Mac OS)
 *   ``~/.mozilla/firefox`` (Linux)
 *   ``~/snap/firefox/common/.mozilla/firefox`` (Firefox Snap for Linux)
+*   ``~/.var/app/org.mozilla.firefox/.mozilla/firefox`` (Firefox Flatpak for Linux)
 
 Only profile subdirectories that contain a ``prefs.js`` file
 will be considered valid by the plugin.

--- a/changelog.d/20230512_103013_kurtmckee_support_linux_flatpak.rst
+++ b/changelog.d/20230512_103013_kurtmckee_support_linux_flatpak.rst
@@ -1,0 +1,4 @@
+Added
+-----
+
+-   Support Firefox Flatpak for Linux profile directories.

--- a/dotbot_firefox.py
+++ b/dotbot_firefox.py
@@ -46,6 +46,17 @@ def _get_profile_directories() -> typing.Iterable[pathlib.Path]:
         snap_user_common = "~/snap/firefox/common"
         defaults.append(f"{snap_user_common}/.mozilla/firefox")
 
+        # When Firefox is installed and run as a flatpak,
+        # it stores its profile info under this directory:
+        #
+        #     $HOME/.var/app/org.mozilla.firefox
+        #
+        # $HOME can be customized inside the flatpak sandbox environment,
+        # but it seems unlikely that this level of customization will be needed.
+        #
+        flatpak_home = "~/.var/app/org.mozilla.firefox"
+        defaults.append(f"{flatpak_home}/.mozilla/firefox")
+
     for default in defaults:
         path = pathlib.Path(os.path.expandvars(os.path.expanduser(default)))
         if not path.is_dir():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,12 +20,13 @@ import dotbot_firefox
 
 
 @pytest.fixture(
-    ids=("windows", "mac", "linux", "linux-snap"),
+    ids=("windows", "mac", "linux", "linux-snap", "linux-flatpak"),
     params=(
         ("win32", "/adrift/win32/appdata/Mozilla/Firefox/Profiles/bogus"),
         ("darwin", "/adrift/darwin/Library/Application Support/Firefox/Profiles/bogus"),
         ("linux", "/adrift/linux/.mozilla/firefox/bogus"),
         ("linux", "/adrift/linux/snap/firefox/common/.mozilla/firefox/bogus"),
+        ("linux", "/adrift/linux/.var/app/org.mozilla.firefox/.mozilla/firefox/bogus"),
     ),
 )
 def get_profile(request, fs, monkeypatch):


### PR DESCRIPTION
Added
-----

-   Support Firefox Flatpak for Linux profile directories.
