### PR TITLE
Use hashes as GitHub action identifiers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,11 +15,11 @@ jobs:
       wheel-filename: "${{ steps.get-filename.outputs.wheel-filename }}"
     steps:
       - name: "Checkout branch"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608" # v4.1.0
 
       - name: "Setup Python"
         id: "setup-python"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236" # v4.7.1
         with:
           python-version: "3.11"
           cache: "pip"
@@ -36,7 +36,7 @@ jobs:
         run: 'echo "wheel-filename=$(ls -1 dotbot_firefox*.whl | head -n 1)" >> $GITHUB_OUTPUT'
 
       - name: "Upload the build artifact"
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32" # v3.1.3
         with:
           name: "dotbot_firefox-${{ github.sha }}.whl"
           path: "${{ steps.get-filename.outputs.wheel-filename }}"
@@ -95,11 +95,11 @@ jobs:
         run: "date +'%V' > week-number.txt"
 
       - name: "Checkout branch"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608" # v4.1.0
 
       - name: "Setup Pythons"
         id: "setup-python"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236" # v4.7.1
         with:
           python-version: "${{ matrix.run.pythons }}"
           allow-prereleases: true
@@ -114,7 +114,7 @@ jobs:
 
       - name: "Restore cache"
         id: "restore-cache"
-        uses: "actions/cache@v3"
+        uses: "actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84" # v3.3.2
         with:
           path: |
             .tox/
@@ -133,7 +133,7 @@ jobs:
           ${{ env.venv-path }}/pip install tox
 
       - name: "Download the build artifact"
-        uses: "actions/download-artifact@v3"
+        uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a" # v3.0.2
         with:
           name: "dotbot_firefox-${{ github.sha }}.whl"
 
@@ -154,11 +154,11 @@ jobs:
         run: "date +'%V' > week-number.txt"
 
       - name: "Checkout branch"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608" # v4.1.0
 
       - name: "Setup Pythons"
         id: "setup-python"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236" # v4.7.1
         with:
           python-version: "3.11"
           # Cache packages that pip downloads.
@@ -172,7 +172,7 @@ jobs:
 
       - name: "Restore cache"
         id: "restore-cache"
-        uses: "actions/cache@v3"
+        uses: "actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84" # v3.3.2
         with:
           path: |
             .mypy_cache/
@@ -188,7 +188,7 @@ jobs:
           .venv/bin/pip install tox
 
       - name: "Download the build artifact"
-        uses: "actions/download-artifact@v3"
+        uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a" # v3.0.2
         with:
           name: "dotbot_firefox-${{ github.sha }}.whl"
 


### PR DESCRIPTION

Use hashes as GitHub action identifiers, which is a best practice.

Dependabot has the ability to update hashes together with the tag name in trailing comments.

## How this change was made

The following code was run to generate these changes:

```python
import pathlib
import re


actions = {
    "actions/cache": ("704facf57e6136b1bc63b828d79edcd491f0ee84", "v3.3.2"),
    "actions/checkout": ("8ade135a41bc03ea155e62e844d188df1ea18608", "v4.1.0"),
    "actions/download-artifact": ("9bc31d5ccc31df68ecc42ccf4149144866c47d8a", "v3.0.2"),
    "actions/setup-python": ("65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236", "v4.7.1"),
    "actions/upload-artifact": ("a8a3f3ad30e3422c9c7b888a15615d19a852ae32", "v3.1.3"),
    "aws-actions/amazon-ecr-login": ("062b18b96a7aff071d4dc91bc00c4c1a7945b076", "v2.0.1"),
    "aws-actions/configure-aws-credentials": ("010d0da01d0b5a38af31e9c3470dbfdabdecca3a", "v4.0.1"),
    "pypa/gh-action-pypi-publish": ("b7f401de30cb6434a1e19f805ff006643653240e", "v1.8.10"),
    "readthedocs/actions/preview": ("212a0c4917cd5db3f95d08786dd313666fe38cac", "v1.1"),
    "unfor19/install-aws-cli-action": ("3c53dab4dd62b5d9d647f0ce9519285250a3c767", "v1.0.6"),
}


def replacer(match_obj: re.Match) -> str:
    if "@main" in match_obj.string:
        return match_obj.string

    action = match_obj.group("action")
    id_ = match_obj.group("id")
    hash_, version_ = actions[action]
    return match_obj.string.replace(id_, hash_) + f" # {version_}"


def main():
    pattern = re.compile("""^ +-? uses: ["']?(?P<action>[^@]+)@(?P<id>[^"']+)["']?$""")

    workflows = list(pathlib.Path(".github/workflows").rglob("*.yaml"))
    workflows += list(pathlib.Path(".github/workflows").rglob("*.yml"))

    for workflow in workflows:
        original_text = workflow.read_text()
        lines = []
        for line in original_text.splitlines():
            lines.append(pattern.sub(replacer, line))
        workflow.write_text("\n".join(lines) + "\n")


if __name__ == "__main__":
    main()
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>