### PR TITLE
Group all Dependabot updates for GitHub actions together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION

This PR introduces the following changes:

*   _(For some repos)_ Introduce a Dependabot config
*   Configure Dependabot to group all GitHub action version updates together.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>