### PR TITLE
Remove tox `isolated_build` config options

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist =
 
 min_version = 4.4.4
 skip_missing_interpreters = true
-isolated_build = true
 labels =
     update=update
 


### PR DESCRIPTION

Tox 4 made this the default, and the option has been removed ([reference](https://tox.wiki/en/latest/upgrading.html#removed-tox-ini-keys)).

This PR removes the option.

## How this change was made

This change was made using search-and-replace across many repositories.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>